### PR TITLE
feat(server,ui): support seasons in API and partly client

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "express": "^4.17.1",
     "luxon": "^1.25.0",
     "pg": "^8.5.1",
+    "postgres-migrations": "^5.3.0",
     "react-simple-pull-to-refresh": "^1.2.3"
   }
 }

--- a/src/model/player.ts
+++ b/src/model/player.ts
@@ -3,6 +3,7 @@ interface Player {
     points: number;
     lastPlayed: string;
     holderOfSnek: boolean;
+    season: number;
 }
 
 export default Player;

--- a/src/model/score.ts
+++ b/src/model/score.ts
@@ -7,6 +7,7 @@ interface Score {
     nettoEagles: number;
     muligans: number;
     date: string;
+    season: number;
 }
 
 export default Score;

--- a/src/repository/migrations/00001_add_season_column.sql
+++ b/src/repository/migrations/00001_add_season_column.sql
@@ -1,0 +1,7 @@
+ALTER TABLE score ADD COLUMN season INTEGER;
+UPDATE score set season = 1;
+ALTER TABLE score ALTER COLUMN season SET NOT NULL;
+
+ALTER TABLE scoreboard ADD COLUMN season INTEGER;
+UPDATE scoreboard set season = 1;
+ALTER TABLE scoreboard ALTER COLUMN season SET NOT NULL;

--- a/src/repository/model/playerEntity.ts
+++ b/src/repository/model/playerEntity.ts
@@ -3,4 +3,5 @@ export interface PlayerEntity {
     points: number;
     holderofsnek: boolean;
     lastplayed: string;
+    season: number;
 }

--- a/src/repository/model/scoreEntity.ts
+++ b/src/repository/model/scoreEntity.ts
@@ -7,4 +7,5 @@ export interface ScoreEntity {
     nettoeagles: number;
     muligans: number;
     date: string;
+    season: number;
 }

--- a/src/repository/repository.ts
+++ b/src/repository/repository.ts
@@ -1,0 +1,14 @@
+import { Client } from 'pg';
+import { migrate } from 'postgres-migrations';
+import * as path from 'path';
+
+export class Repository {
+    client: Client;
+    constructor(client: Client) {
+        this.client = client;
+        this.client.connect();
+        migrate({ client }, path.join(__dirname, './migrations')).catch((error) => {
+            throw new Error(error);
+        });
+    }
+}

--- a/src/repository/scoreboard.ts
+++ b/src/repository/scoreboard.ts
@@ -1,18 +1,16 @@
-import { Client, QueryResult } from 'pg';
+import { QueryResult } from 'pg';
 import Player from '../model/player';
 import Score from '../model/score';
 import { query } from './db';
 import { PlayerEntity } from './model/playerEntity';
 import { ScoreEntity } from './model/scoreEntity';
+import { Repository } from './repository';
 
-export class ScoreboardRepository {
-    constructor(private client: Client) {
-        client.connect();
-    }
-
-    async fetchScoreboard(): Promise<Player[]> {
-        const qry = 'SELECT name,points,holderofsnek,lastplayed from scoreboard';
-        const res: QueryResult<PlayerEntity> = await query<PlayerEntity>(this.client, qry, []);
+export class ScoreboardRepository extends Repository {
+    async fetchScoreboard(season: number): Promise<Player[]> {
+        const qry = 'SELECT name,points,holderofsnek,lastplayed,season from scoreboard where season=$1';
+        const values = [season];
+        const res: QueryResult<PlayerEntity> = await query<PlayerEntity>(this.client, qry, values);
 
         return res.rows.map((row: PlayerEntity) => {
             return {
@@ -20,13 +18,15 @@ export class ScoreboardRepository {
                 points: row.points,
                 holderOfSnek: row.holderofsnek,
                 lastPlayed: row.lastplayed,
+                season: row.season,
             };
         });
     }
 
-    async findScores(name: string): Promise<Score[]> {
-        const qry = 'SELECT id,name,points,holderofsnek,nettotweets,nettoeagles,muligans,date from score where name=$1';
-        const values = [name];
+    async findScores(name: string, season: number): Promise<Score[]> {
+        const qry =
+            'SELECT id,name,points,holderofsnek,nettotweets,nettoeagles,muligans,date,season from score where name=$1 AND season=$2';
+        const values = [name, season];
         const res: QueryResult<ScoreEntity> = await query<ScoreEntity>(this.client, qry, values);
 
         return res.rows.map((row: ScoreEntity) => {
@@ -39,13 +39,14 @@ export class ScoreboardRepository {
                 nettoEagles: row.nettoeagles,
                 muligans: row.muligans,
                 date: row.date,
+                season: row.season,
             };
         });
     }
 
     async addScore(score: Score): Promise<Player[]> {
         const qry =
-            'INSERT INTO score(name, points, holderOfSnek, nettoTweets, nettoEagles, muligans, date) VALUES($1, $2, $3, $4, $5, $6, $7)';
+            'INSERT INTO score(name, points, holderOfSnek, nettoTweets, nettoEagles, muligans, date, season) VALUES($1, $2, $3, $4, $5, $6, $7, $8)';
         const values = [
             score.name,
             score.points,
@@ -54,6 +55,7 @@ export class ScoreboardRepository {
             score.nettoEagles,
             score.muligans,
             new Date().toISOString().split('T')[0],
+            score.season,
         ];
 
         await query(this.client, qry, values);
@@ -63,7 +65,7 @@ export class ScoreboardRepository {
     async removeScore(id: number): Promise<void> {
         const values = [id];
         const select_qry =
-            'SELECT id,name,points,nettotweets,nettoeagles,muligans,date,holderofsnek FROM score where id=$1';
+            'SELECT id,name,points,nettotweets,nettoeagles,muligans,date,holderofsnek,season FROM score where id=$1';
         const delete_qry = 'DELETE FROM score where id=$1';
 
         const res = await query<ScoreEntity>(this.client, select_qry, values);
@@ -76,6 +78,7 @@ export class ScoreboardRepository {
             muligans: res.rows[0].muligans,
             date: res.rows[0].date,
             holderOfSnek: res.rows[0].holderofsnek,
+            season: res.rows[0].season,
         };
 
         await query(this.client, delete_qry, values);
@@ -84,16 +87,17 @@ export class ScoreboardRepository {
 
     private async removeFromScoreboard(score: Score): Promise<void> {
         const points = this.calculatePoints(score.points, score.nettoTweets, score.nettoEagles, score.muligans);
-        const lastPlayed = await this.getLastPlayedDate(score.name);
-        const qry = 'UPDATE scoreboard set points=points-$1, lastplayed=$2, holderofsnek=false where name=$3';
-        const values = [points, lastPlayed, score.name];
+        const lastPlayed = await this.getLastPlayedDate(score.name, score.season);
+        const qry =
+            'UPDATE scoreboard set points=points-$1, lastplayed=$2, holderofsnek=false where name=$3 AND season=$4';
+        const values = [points, lastPlayed, score.name, score.season];
 
         await query(this.client, qry, values);
     }
 
-    private async findPlayer(name: string): Promise<Player> {
-        const qry = 'SELECT points,holderofsnek,lastplayed,name from scoreboard where name=$1';
-        const values = [name];
+    private async findPlayer(name: string, season: number): Promise<Player> {
+        const qry = 'SELECT points,holderofsnek,lastplayed,name,season from scoreboard where name=$1 and season=$2';
+        const values = [name, season];
         const res = await query<PlayerEntity>(this.client, qry, values);
         // Should only be one hit
         const data = res.rows[0];
@@ -102,19 +106,26 @@ export class ScoreboardRepository {
             holderOfSnek: data.holderofsnek,
             lastPlayed: data.lastplayed,
             name: data.name,
+            season: data.season,
         };
     }
 
     private async updateScoreboard(score: Score): Promise<Player[]> {
-        const player = await this.findPlayer(score.name);
+        const player = await this.findPlayer(score.name, score.season);
         const updatedPlayer = this.updatePlayerScore(score, player);
-        const qry = 'UPDATE scoreboard set points=$1, holderOfSnek=$2, lastPlayed=$3 where name=$4';
-        const values = [updatedPlayer.points, updatedPlayer.holderOfSnek, updatedPlayer.lastPlayed, updatedPlayer.name];
+        const qry = 'UPDATE scoreboard set points=$1, holderOfSnek=$2, lastPlayed=$3 where name=$4 AND season=$5';
+        const values = [
+            updatedPlayer.points,
+            updatedPlayer.holderOfSnek,
+            updatedPlayer.lastPlayed,
+            updatedPlayer.name,
+            score.season,
+        ];
         await query(this.client, qry, values);
         if (score.holderOfSnek) {
-            await this.updateSnekHolder(score.name);
+            await this.updateSnekHolder(score.name, score.season);
         }
-        return await this.fetchScoreboard();
+        return await this.fetchScoreboard(score.season);
     }
 
     private calculatePoints(stablePoints: number, nettoTweets: number, nettoEagles: number, muligans: number): number {
@@ -133,15 +144,15 @@ export class ScoreboardRepository {
         return player;
     }
 
-    async updateSnekHolder(newSnekHolder: string): Promise<void> {
-        const qry = 'UPDATE scoreboard set holderOfSnek=false where name !=$1';
-        const values = [newSnekHolder];
+    async updateSnekHolder(newSnekHolder: string, season: number): Promise<void> {
+        const qry = 'UPDATE scoreboard set holderOfSnek=false where name !=$1 and season=$2';
+        const values = [newSnekHolder, season];
         await query(this.client, qry, values);
     }
 
-    async getLastPlayedDate(name: string): Promise<string> {
-        const qry = 'SELECT MAX(date) as lastplayed from score where name=$1';
-        const values = [name];
+    async getLastPlayedDate(name: string, season: number): Promise<string> {
+        const qry = 'SELECT MAX(date) as lastplayed from score where name=$1 AND season=$2';
+        const values = [name, season];
         const res = await query<{ lastplayed: string }>(this.client, qry, values);
         const data = res.rows[0];
         return data.lastplayed;

--- a/src/routes/scoreboard.ts
+++ b/src/routes/scoreboard.ts
@@ -6,17 +6,14 @@ import { ScoreboardService } from '../service/scoreboard';
 export const createScoreboardRouter = (scoreboardService: ScoreboardService): Router => {
     const router = Router();
 
-    router.get('/', async (_req, res) => {
-        const scoreboard: Player[] = await scoreboardService.getScoreboard();
-        scoreboard.sort((a: Player, b: Player) => {
-            if (b.lastPlayed === '' || b.lastPlayed === null) {
-                return -1;
-            }
-            if (a.lastPlayed === '' || a.lastPlayed === null) {
-                return 1;
-            }
-            return b.points > a.points ? 1 : -1;
-        });
+    router.get('/', async (req, res) => {
+        const season = req.query.season as string;
+        if (!season) {
+            throw new Error('Missing season in request');
+        }
+
+        const scoreboard: Player[] = await scoreboardService.getScoreboard(parseInt(season));
+
         res.json(scoreboard);
     });
 

--- a/src/routes/scores.ts
+++ b/src/routes/scores.ts
@@ -7,7 +7,12 @@ export const createScoreRouter = (scoreboardService: ScoreboardService): Router 
 
     router.get('/', async (req, res) => {
         const name: string = req.query.name as string;
-        const scores: Score[] = await scoreboardService.getScores(name);
+        const season: string = req.query.season as string;
+        if (!name || !season) {
+            throw new Error('name and season must be included');
+        }
+
+        const scores: Score[] = await scoreboardService.getScores(name, parseInt(season));
         scores.sort((a: Score, b: Score) => {
             return b.date > a.date ? 1 : -1;
         });

--- a/src/server.ts
+++ b/src/server.ts
@@ -12,10 +12,10 @@ export interface ServerOptions {
 
 export const createServer = (servierOptions: ServerOptions): Express => {
     const app = express();
+    app.use(bodyParser.json());
     app.use('/scoreboard', createScoreboardRouter(servierOptions.scoreboardService));
     app.use('/score', createScoreRouter(servierOptions.scoreboardService));
 
-    app.use(bodyParser.json());
     // Serve frontend
     if (servierOptions.env === 'production') {
         // Serve any static files

--- a/src/service/scoreboard.ts
+++ b/src/service/scoreboard.ts
@@ -5,16 +5,26 @@ import Score from '../model/score';
 export class ScoreboardService {
     constructor(private scoreboardRepository: ScoreboardRepository) {}
 
-    async getScoreboard(): Promise<Player[]> {
-        return this.scoreboardRepository.fetchScoreboard();
+    async getScoreboard(season: number): Promise<Player[]> {
+        const scoreboard = await this.scoreboardRepository.fetchScoreboard(season);
+        scoreboard.sort((a: Player, b: Player) => {
+            if (b.lastPlayed === '' || b.lastPlayed === null) {
+                return -1;
+            }
+            if (a.lastPlayed === '' || a.lastPlayed === null) {
+                return 1;
+            }
+            return b.points > a.points ? 1 : -1;
+        });
+        return scoreboard;
     }
 
     async addScoreToScoreboard(score: Score): Promise<Player[]> {
         return await this.scoreboardRepository.addScore(score);
     }
 
-    async getScores(name: string): Promise<Score[]> {
-        return await this.scoreboardRepository.findScores(name);
+    async getScores(name: string, season: number): Promise<Score[]> {
+        return await this.scoreboardRepository.findScores(name, season);
     }
 
     async deleteScore(id: number): Promise<void> {

--- a/ui/src/components/appbar/AppBar.tsx
+++ b/ui/src/components/appbar/AppBar.tsx
@@ -7,6 +7,7 @@ import { ScorecardForm } from '../scorecard/ScorecardForm';
 import Scoreboard, { Player } from '../scoreboard/Scoreboard';
 import PullToRefresh from 'react-simple-pull-to-refresh';
 import { GetPlayerScores, GetScoreboard } from '../../services/ScoreboardService';
+import season from '../season';
 
 const useStyles = makeStyles((theme: Theme) =>
     createStyles({
@@ -31,10 +32,10 @@ export default function ButtonAppBar() {
     }, []);
 
     const fetchScoreboard = async () => {
-        const res = await GetScoreboard();
+        const res = await GetScoreboard(season);
         let scoresState = new Map();
         res.forEach((player: Player) => {
-            GetPlayerScores(player.name).then((scores) => {
+            GetPlayerScores(player.name, season).then((scores) => {
                 scoresState.set(player.name, scores);
             });
         });

--- a/ui/src/components/scoreboard/Scoreboard.tsx
+++ b/ui/src/components/scoreboard/Scoreboard.tsx
@@ -30,6 +30,7 @@ export type Player = {
     points: number;
     lastPlayed: string;
     holderOfSnek: boolean;
+    season: number;
 };
 
 type Score = {
@@ -41,6 +42,7 @@ type Score = {
     nettoEagles: number;
     muligans: number;
     date: string;
+    season: number;
 };
 
 export default function Scoreboard(props: {

--- a/ui/src/components/scorecard/ScorecardForm.tsx
+++ b/ui/src/components/scorecard/ScorecardForm.tsx
@@ -9,6 +9,7 @@ import DialogTitle from '@material-ui/core/DialogTitle';
 import MenuItem from '@material-ui/core/MenuItem';
 import { SubmitScorecard } from '../../services/ScoreboardService';
 import useSound from 'use-sound';
+import season from '../season';
 
 type Scorecard = {
     name: string;
@@ -17,6 +18,7 @@ type Scorecard = {
     nettoTweets: number;
     nettoEagles: number;
     muligans: number;
+    season: number;
 };
 
 export function ScorecardForm(props: { updateState: () => Promise<void> }) {
@@ -86,6 +88,7 @@ export function ScorecardForm(props: { updateState: () => Promise<void> }) {
             nettoTweets: +nettoTweets,
             nettoEagles: +nettoEagles,
             muligans: +muligans,
+            season: season,
         };
         if (scorecard.holderOfSnek) {
             playSnek();

--- a/ui/src/components/season.ts
+++ b/ui/src/components/season.ts
@@ -1,0 +1,3 @@
+const season = 1;
+
+export default season;

--- a/ui/src/services/ScoreboardService.ts
+++ b/ui/src/services/ScoreboardService.ts
@@ -1,5 +1,5 @@
-export async function GetScoreboard() {
-    const response = await fetch('/scoreboard');
+export async function GetScoreboard(season: number) {
+    const response = await fetch(`/scoreboard?season=${season}`);
     return await response.json();
 }
 
@@ -14,8 +14,8 @@ export async function SubmitScorecard(body: string) {
     });
 }
 
-export async function GetPlayerScores(name: string) {
-    const response = await fetch('/score?name=' + name);
+export async function GetPlayerScores(name: string, season: number) {
+    const response = await fetch(`/score?name=${name}&season=${season}`);
     return await response.json();
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1423,7 +1423,7 @@ pg-types@^2.1.0, pg-types@^2.2.0:
     postgres-date "~1.0.4"
     postgres-interval "^1.1.0"
 
-pg@^8.5.1:
+pg@^8.5.1, pg@^8.6.0:
   version "8.7.1"
   resolved "https://registry.yarnpkg.com/pg/-/pg-8.7.1.tgz#9ea9d1ec225980c36f94e181d009ab9f4ce4c471"
   integrity sha512-7bdYcv7V6U3KAtWjpQJJBww0UEsWuh4yQ/EjNf2HeO/NnvKjpvhEIe/A/TleP6wtmSKnUnghs5A9jUoK6iDdkA==
@@ -1469,6 +1469,14 @@ postgres-interval@^1.1.0:
   integrity sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==
   dependencies:
     xtend "^4.0.0"
+
+postgres-migrations@^5.3.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/postgres-migrations/-/postgres-migrations-5.3.0.tgz#3a8a98f25994e95f0a79de7f315d086fcfc51b94"
+  integrity sha512-gnTHWJZVWbW8T3mXIxJm1JRU853TqBVWkhgfsTJr7zqT3VexjRmJj9kNi96rVhfTezDU4FVW6pf701kLOZiKIA==
+  dependencies:
+    pg "^8.6.0"
+    sql-template-strings "^2.2.2"
 
 prelude-ls@^1.2.1:
   version "1.2.1"
@@ -1718,6 +1726,11 @@ sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
+
+sql-template-strings@^2.2.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/sql-template-strings/-/sql-template-strings-2.2.2.tgz#3f11508a25addfce217a3042a9d300c3193b96ff"
+  integrity sha1-PxFQiiWt384hejBCqdMAwxk7lv8=
 
 "statuses@>= 1.5.0 < 2", statuses@~1.5.0:
   version "1.5.0"


### PR DESCRIPTION
In order to be able to keep historic data while also start from fresh we introduce seasons.
This mr does the following:
* Add season as a column to both scoreboard and score table
* Makes sure the API fetches and store data on the appropirate season.
* Fixes an issue with posting json from previous commit
* UI have season hardcoded for now, but should be a choice in later versions